### PR TITLE
fix: message box and message details window overlapping issue

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -10,13 +10,14 @@
 
 .chat-window-container {
     width: 70%;
-    height: 100vh;
+    height: 90vh;
     overflow-x: hidden;
     background-color: black;
 }
 
 .chat-action-bar-container {
     position: fixed;
+    height: 10vh;
     bottom: 0;
     width: 100%;
 }

--- a/src/app/chat-action-bar/chat-action-bar.component.html
+++ b/src/app/chat-action-bar/chat-action-bar.component.html
@@ -1,7 +1,7 @@
 <div class="action-bar">
     <mat-form-field class="form-field">
         <mat-label>Your message goes here</mat-label>
-        <input matInput placeholder="start typing..." [(ngModel)]="message">
+        <input matInput placeholder="start typing..." [(ngModel)]="message" (keydown.enter)="send()">
     </mat-form-field>
     <button mat-button (click)="send()">Send</button>
 </div>


### PR DESCRIPTION
changed height of 'chat-window-container' to 90vh and 'chat-action-bar-container' to 10vh